### PR TITLE
Tofn compatibility fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.5.0"
 default = ["rust"]
 gmp = ["hex", "rand/default", "rug"]
 rust = ["glass_pumpkin", "num-bigint", "num-integer", "num-traits", "rand/default"]
-wasm = ["getrandom", "wasm-bindgen"]
+wasm = ["getrandom", "wasm-bindgen", "serde-wasm-bindgen"]
 
 [dependencies]
 digest = "0.9"
@@ -37,6 +37,7 @@ serde = { version = "1.0", features = ["serde_derive"] }
 subtle = "2.4"
 wasm-bindgen = { version = "0.2", default-features = false, features = ["serde-serialize"], optional = true }
 zeroize = "1.4"
+serde-wasm-bindgen = { version = "0.4", optional = true }
 
 [dev-dependencies]
 blake2 = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.5.0"
 
 [features]
 default = ["rust"]
-gmp = ["hex", "rand/default", "rug"]
+gmp = ["hex", "rand/default", "rug/num-traits", "num-traits"]
 rust = ["glass_pumpkin", "num-bigint", "num-integer", "num-traits", "rand/default"]
 wasm = ["getrandom", "wasm-bindgen", "serde-wasm-bindgen"]
 
@@ -43,3 +43,4 @@ serde-wasm-bindgen = { version = "0.4", optional = true }
 blake2 = "0.9"
 multibase = "0.9"
 serde_json = "1.0"
+bincode = "1.3"

--- a/src/gmp_backend.rs
+++ b/src/gmp_backend.rs
@@ -260,11 +260,17 @@ impl Bn {
 
     /// Generate a safe prime with `size` bits
     pub fn safe_prime(size: usize) -> Self {
+        Self::safe_prime_from_rng(size, &mut GmpRand::default())
+    }
+
+    /// Generate a safe prime with `size` bits with a user-provided rng
+    pub fn safe_prime_from_rng(size: usize, rng: &mut impl RngCore) -> Self {
         use rug::integer::IsPrime;
 
-        let mut rng = GmpRand::default();
+        let mut e_rng = ExternalRand { rng };
+
         loop {
-            let mut p = _random_nbit(size - 1, &mut rng);
+            let mut p = _random_nbit(size - 1, &mut e_rng);
 
             // Set the MSB bit so that we're sampling from [2^(size - 2), 2^(size - 1))
             p.set_bit((size - 2) as u32, true);

--- a/src/gmp_backend.rs
+++ b/src/gmp_backend.rs
@@ -188,6 +188,11 @@ impl Bn {
         self.0 == Integer::from(1)
     }
 
+    /// Return the bit length
+    pub fn bit_length(&self) -> usize {
+        self.0.significant_bits() as usize
+    }
+
     /// Compute the greatest common divisor
     pub fn gcd(&self, other: &Bn) -> Self {
         Self(self.0.gcd_ref(&other.0).complete())

--- a/src/gmp_backend.rs
+++ b/src/gmp_backend.rs
@@ -281,8 +281,13 @@ impl Bn {
 
     /// Generate a prime with `size` bits
     pub fn prime(size: usize) -> Self {
-        let mut gmprng = GmpRand::default();
-        let mut p = _random_nbit(size, &mut gmprng);
+        Self::prime_from_rng(size, &mut GmpRand::default())
+    }
+
+    /// Generate a prime with `size` bits with a user-provided rng
+    pub fn prime_from_rng(size: usize, rng: &mut impl RngCore) -> Self {
+        let mut e_rng = ExternalRand { rng };
+        let mut p = _random_nbit(size, &mut e_rng);
 
         // Set the MSB bit so that we're sampling from [2^(size - 1), 2^size)
         p.set_bit((size - 1) as u32, true);

--- a/src/gmp_backend.rs
+++ b/src/gmp_backend.rs
@@ -3,10 +3,8 @@
     SPDX-License-Identifier: Apache-2.0
 */
 use crate::{get_mod, GcdResult};
-use rand::{Error, RngCore};
-use rug::rand::ThreadRandState;
-use rug::{Assign, Complete, Integer};
-use std::{
+use alloc::vec::Vec;
+use core::{
     cmp::{Eq, Ordering, PartialEq, PartialOrd},
     fmt::{self, Debug, Display},
     iter::{Product, Sum},
@@ -15,6 +13,9 @@ use std::{
         SubAssign,
     },
 };
+use rand::{Error, RngCore};
+use rug::rand::ThreadRandState;
+use rug::{Assign, Complete, Integer};
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 

--- a/src/gmp_backend.rs
+++ b/src/gmp_backend.rs
@@ -23,23 +23,23 @@ use zeroize::Zeroize;
 pub struct Bn(pub(crate) Integer);
 
 clone_impl!(|b: &Bn| b.0.clone());
-default_impl!(|| Integer::new());
+default_impl!(Integer::new);
 display_impl!();
 eq_impl!();
 #[cfg(target_pointer_width = "64")]
-from_impl!(|d: i128| Integer::from(d), i128);
+from_impl!(Integer::from, i128);
 #[cfg(target_pointer_width = "64")]
-from_impl!(|d: u128| Integer::from(d), u128);
-from_impl!(|d: usize| Integer::from(d), usize);
-from_impl!(|d: u64| Integer::from(d), u64);
-from_impl!(|d: u32| Integer::from(d), u32);
-from_impl!(|d: u16| Integer::from(d), u16);
-from_impl!(|d: u8| Integer::from(d), u8);
-from_impl!(|d: isize| Integer::from(d), isize);
-from_impl!(|d: i64| Integer::from(d), i64);
-from_impl!(|d: i32| Integer::from(d), i32);
-from_impl!(|d: i16| Integer::from(d), i16);
-from_impl!(|d: i8| Integer::from(d), i8);
+from_impl!(Integer::from, u128);
+from_impl!(Integer::from, usize);
+from_impl!(Integer::from, u64);
+from_impl!(Integer::from, u32);
+from_impl!(Integer::from, u16);
+from_impl!(Integer::from, u8);
+from_impl!(Integer::from, isize);
+from_impl!(Integer::from, i64);
+from_impl!(Integer::from, i32);
+from_impl!(Integer::from, i16);
+from_impl!(Integer::from, i8);
 iter_impl!();
 serdes_impl!(
     |b: &Bn| b.0.to_string_radix(16),
@@ -196,7 +196,7 @@ impl Bn {
 
     /// self == 1
     pub fn is_one(&self) -> bool {
-        self.0 == Integer::from(1)
+        self.0 == 1
     }
 
     /// Return the bit length

--- a/src/group.rs
+++ b/src/group.rs
@@ -27,7 +27,7 @@ macro_rules! binops_group {
             type Output = BigNumber;
 
             fn $func(self, pair: (&'a BigNumber, BigNumber)) -> Self::Output {
-                self + (pair.0, &pair.1)
+                self.$func((pair.0, &pair.1))
             }
         }
 
@@ -35,7 +35,7 @@ macro_rules! binops_group {
             type Output = BigNumber;
 
             fn $func(self, pair: (BigNumber, &'b BigNumber)) -> Self::Output {
-                self + (&pair.0, pair.1)
+                self.$func((&pair.0, pair.1))
             }
         }
 
@@ -43,7 +43,7 @@ macro_rules! binops_group {
             type Output = BigNumber;
 
             fn $func(self, pair: (BigNumber, BigNumber)) -> Self::Output {
-                self + (&pair.0, &pair.1)
+                self.$func((&pair.0, &pair.1))
             }
         }
 
@@ -51,7 +51,7 @@ macro_rules! binops_group {
             type Output = BigNumber;
 
             fn $func(self, pair: (&'a BigNumber, &'b BigNumber)) -> Self::Output {
-                &self + pair
+                (&self).$func(pair)
             }
         }
 
@@ -59,7 +59,7 @@ macro_rules! binops_group {
             type Output = BigNumber;
 
             fn $func(self, pair: (&'a BigNumber, BigNumber)) -> Self::Output {
-                &self + (pair.0, &pair.1)
+                (&self).$func((pair.0, &pair.1))
             }
         }
 
@@ -67,7 +67,7 @@ macro_rules! binops_group {
             type Output = BigNumber;
 
             fn $func(self, pair: (BigNumber, &'b BigNumber)) -> Self::Output {
-                &self + (&pair.0, pair.1)
+                (&self).$func((&pair.0, pair.1))
             }
         }
 
@@ -75,7 +75,7 @@ macro_rules! binops_group {
             type Output = BigNumber;
 
             fn $func(self, pair: (BigNumber, BigNumber)) -> Self::Output {
-                &self + (&pair.0, &pair.1)
+                (&self).$func((&pair.0, &pair.1))
             }
         }
     };
@@ -90,7 +90,7 @@ macro_rules! binops_group_assign {
 
         impl<'a, 'c> $ops<(&'a mut BigNumber, BigNumber)> for &'c Group {
             fn $func(&mut self, pair: (&'a mut BigNumber, BigNumber)) {
-                *self += (pair.0, &pair.1)
+                (*self).$func((pair.0, &pair.1))
             }
         }
 
@@ -102,7 +102,7 @@ macro_rules! binops_group_assign {
 
         impl<'a> $ops<(&'a mut BigNumber, BigNumber)> for Group {
             fn $func(&mut self, pair: (&'a mut BigNumber, BigNumber)) {
-                *self += (pair.0, &pair.1)
+                (*self).$func((pair.0, &pair.1))
             }
         }
     };

--- a/src/group.rs
+++ b/src/group.rs
@@ -4,7 +4,7 @@
 */
 use crate::BigNumber;
 
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 /// Represents a cyclic group where all operations are reduced by a modulus.
 /// Purely a convenience struct to avoid having to call mod{ops}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //! The modulus is not known at compile time which excludes using certain traits like `ff::PrimeField`, so
 //! unfortunately, the caller needs to remember to use methods prefixed with `mod` to achieve the desired results.
 
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(
     missing_docs,
@@ -30,6 +31,8 @@
     while_true,
     warnings
 )]
+
+extern crate alloc;
 
 #[macro_use]
 mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -214,42 +214,71 @@ macro_rules! clone_impl {
 }
 
 macro_rules! serdes_impl {
-    ($ser:expr, $des:expr) => {
-        impl Serialize for Bn {
+    ($ser_str:expr, $des_str:expr, $ser_bytes:expr, $des_bytes:expr) => {
+        impl serde::Serialize for Bn {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
-                S: Serializer,
+                S: serde::Serializer,
             {
-                let str = $ser(self);
-                serializer.serialize_str(&str)
+                if serializer.is_human_readable() {
+                    let str = $ser_str(self);
+                    serializer.serialize_str(&str)
+                } else {
+                    let bytes = $ser_bytes(self);
+                    serializer.serialize_bytes(&bytes)
+                }
             }
         }
 
-        impl<'de> Deserialize<'de> for Bn {
+        impl<'de> serde::Deserialize<'de> for Bn {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
-                D: Deserializer<'de>,
+                D: serde::Deserializer<'de>,
             {
-                struct BnVisitor;
+                struct BnVisitorStr;
+                struct BnVisitorBytes;
 
-                impl<'de> Visitor<'de> for BnVisitor {
+                impl<'de> serde::de::Visitor<'de> for BnVisitorStr {
                     type Value = Bn;
 
                     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                         write!(f, "a hex encoded string")
                     }
 
-                    fn visit_str<E>(self, s: &str) -> Result<Bn, E>
+                    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
                     where
-                        E: DError,
+                        E: serde::de::Error,
                     {
-                        let b = $des(s)
-                            .map_err(|_| DError::invalid_value(Unexpected::Str(s), &self))?;
+                        let b = $des_str(s).ok_or_else(|| {
+                            serde::de::Error::invalid_value(serde::de::Unexpected::Str(s), &self)
+                        })?;
                         Ok(Bn(b))
                     }
                 }
 
-                deserializer.deserialize_str(BnVisitor)
+                impl<'de> serde::de::Visitor<'de> for BnVisitorBytes {
+                    type Value = Bn;
+
+                    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        write!(f, "a bytestring")
+                    }
+
+                    fn visit_bytes<E>(self, s: &[u8]) -> Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        let b = $des_bytes(s).ok_or_else(|| {
+                            serde::de::Error::invalid_value(serde::de::Unexpected::Bytes(s), &self)
+                        })?;
+                        Ok(Bn(b))
+                    }
+                }
+
+                if deserializer.is_human_readable() {
+                    deserializer.deserialize_str(BnVisitorStr)
+                } else {
+                    deserializer.deserialize_bytes(BnVisitorBytes)
+                }
             }
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -357,7 +357,7 @@ macro_rules! wasm_slice_impl {
             unsafe fn from_abi(js: Self::Abi) -> Self {
                 let ptr = <*mut u8>::from_abi(js.ptr);
                 let len = js.len as usize;
-                let r = std::slice::from_raw_parts(ptr, len);
+                let r = core::slice::from_raw_parts(ptr, len);
                 $name::from_slice(&r)
             }
         }
@@ -374,7 +374,7 @@ macro_rules! wasm_slice_impl {
             }
         }
 
-        impl std::convert::TryFrom<wasm_bindgen::JsValue> for $name {
+        impl core::convert::TryFrom<wasm_bindgen::JsValue> for $name {
             type Error = &'static str;
 
             fn try_from(value: wasm_bindgen::JsValue) -> Result<Self, Self::Error> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -349,9 +349,7 @@ macro_rules! wasm_slice_impl {
             type Error = &'static str;
 
             fn try_from(value: wasm_bindgen::JsValue) -> Result<Self, Self::Error> {
-                value
-                    .into_serde::<$name>()
-                    .map_err(|_| "unable to deserialize value")
+                serde_wasm_bindgen::from_value(value).map_err(|_| "unable to deserialize value")
             }
         }
     };

--- a/src/openssl_backend.rs
+++ b/src/openssl_backend.rs
@@ -3,9 +3,8 @@
     SPDX-License-Identifier: Apache-2.0
 */
 use crate::GcdResult;
-use openssl::bn::{BigNum, BigNumContext, BigNumRef};
-use rand::RngCore;
-use std::{
+use alloc::vec::Vec;
+use core::{
     cmp::{Eq, Ordering, PartialEq, PartialOrd},
     fmt::{self, Debug, Display},
     iter::{Product, Sum},
@@ -15,6 +14,8 @@ use std::{
         SubAssign,
     },
 };
+use openssl::bn::{BigNum, BigNumContext, BigNumRef};
+use rand::RngCore;
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 

--- a/src/openssl_backend.rs
+++ b/src/openssl_backend.rs
@@ -229,7 +229,7 @@ impl Bn {
         let mut ctx = BigNumContext::new().unwrap();
         let mut bn = BigNum::new().unwrap();
         if exponent.0.is_negative() {
-            match self.invert(&n) {
+            match self.invert(n) {
                 None => {}
                 Some(a) => {
                     let e = -exponent.clone();
@@ -390,7 +390,7 @@ impl Bn {
             let q = r.1.clone() / r.0.clone();
             let f = |mut r: (Self, Self)| {
                 swap(&mut r.0, &mut r.1);
-                r.0 = r.0 - q.clone() * r.1.clone();
+                r.0 -= q.clone() * r.1.clone();
                 r
             };
             r = f(r);

--- a/src/openssl_backend.rs
+++ b/src/openssl_backend.rs
@@ -315,6 +315,11 @@ impl Bn {
         self.0.num_bits() == 1 && self.0.is_bit_set(0)
     }
 
+    /// Return the bit length
+    pub fn bit_length(&self) -> usize {
+        self.0.num_bits() as usize
+    }
+
     /// Compute the greatest common divisor
     pub fn gcd(&self, other: &Bn) -> Self {
         let mut bn = BigNum::new().unwrap();

--- a/src/rust_backend.rs
+++ b/src/rust_backend.rs
@@ -29,23 +29,23 @@ use zeroize::Zeroize;
 pub struct Bn(pub(crate) BigInt);
 
 clone_impl!(|b: &Bn| b.0.clone());
-default_impl!(|| BigInt::default());
+default_impl!(BigInt::default);
 display_impl!();
 eq_impl!();
 #[cfg(target_pointer_width = "64")]
-from_impl!(|d: i128| BigInt::from(d), i128);
+from_impl!(BigInt::from, i128);
 #[cfg(target_pointer_width = "64")]
-from_impl!(|d: u128| BigInt::from(d), u128);
-from_impl!(|d: usize| BigInt::from(d), usize);
-from_impl!(|d: u64| BigInt::from(d), u64);
-from_impl!(|d: u32| BigInt::from(d), u32);
-from_impl!(|d: u16| BigInt::from(d), u16);
-from_impl!(|d: u8| BigInt::from(d), u8);
-from_impl!(|d: isize| BigInt::from(d), isize);
-from_impl!(|d: i64| BigInt::from(d), i64);
-from_impl!(|d: i32| BigInt::from(d), i32);
-from_impl!(|d: i16| BigInt::from(d), i16);
-from_impl!(|d: i8| BigInt::from(d), i8);
+from_impl!(BigInt::from, u128);
+from_impl!(BigInt::from, usize);
+from_impl!(BigInt::from, u64);
+from_impl!(BigInt::from, u32);
+from_impl!(BigInt::from, u16);
+from_impl!(BigInt::from, u8);
+from_impl!(BigInt::from, isize);
+from_impl!(BigInt::from, i64);
+from_impl!(BigInt::from, i32);
+from_impl!(BigInt::from, i16);
+from_impl!(BigInt::from, i8);
 iter_impl!();
 serdes_impl!(
     |b: &Bn| b.0.to_str_radix(16),

--- a/src/rust_backend.rs
+++ b/src/rust_backend.rs
@@ -330,7 +330,13 @@ impl Bn {
 
     /// Generate a prime with `size` bits
     pub fn prime(size: usize) -> Self {
-        let p = prime::new(size).unwrap();
+        let mut rng = rand::thread_rng();
+        Self::prime_from_rng(size, &mut rng)
+    }
+
+    /// Generate a prime with `size` bits with a user-provided rng
+    pub fn prime_from_rng(size: usize, rng: &mut impl RngCore) -> Self {
+        let p = prime::from_rng(size, rng).unwrap();
         Self(p.to_bigint().unwrap())
     }
 

--- a/src/rust_backend.rs
+++ b/src/rust_backend.rs
@@ -3,15 +3,8 @@
     SPDX-License-Identifier: Apache-2.0
 */
 use crate::{get_mod, GcdResult};
-use glass_pumpkin::{prime, safe_prime};
-use num_bigint::{BigInt, Sign, ToBigInt};
-use num_integer::Integer;
-use num_traits::{
-    identities::{One, Zero},
-    Num,
-};
-use rand::RngCore;
-use std::{
+use alloc::{vec, vec::Vec};
+use core::{
     cmp::{Eq, Ord, PartialEq, PartialOrd},
     fmt::{self, Debug, Display},
     iter::{Product, Sum},
@@ -21,6 +14,14 @@ use std::{
         SubAssign,
     },
 };
+use glass_pumpkin::{prime, safe_prime};
+use num_bigint::{BigInt, Sign, ToBigInt};
+use num_integer::Integer;
+use num_traits::{
+    identities::{One, Zero},
+    Num,
+};
+use rand::RngCore;
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 

--- a/src/rust_backend.rs
+++ b/src/rust_backend.rs
@@ -324,7 +324,13 @@ impl Bn {
 
     /// Generate a safe prime with `size` bits
     pub fn safe_prime(size: usize) -> Self {
-        let p = safe_prime::new(size).unwrap();
+        let mut rng = rand::thread_rng();
+        Self::safe_prime_from_rng(size, &mut rng)
+    }
+
+    /// Generate a safe prime with `size` bits with a user-provided rng
+    pub fn safe_prime_from_rng(size: usize, rng: &mut impl RngCore) -> Self {
+        let p = safe_prime::from_rng(size, rng).unwrap();
         Self(p.to_bigint().unwrap())
     }
 

--- a/src/rust_backend.rs
+++ b/src/rust_backend.rs
@@ -11,10 +11,6 @@ use num_traits::{
     Num,
 };
 use rand::RngCore;
-use serde::{
-    de::{Error as DError, Unexpected, Visitor},
-    Deserialize, Deserializer, Serialize, Serializer,
-};
 use std::{
     cmp::{Eq, Ord, PartialEq, PartialOrd},
     fmt::{self, Debug, Display},
@@ -51,9 +47,12 @@ from_impl!(|d: i32| BigInt::from(d), i32);
 from_impl!(|d: i16| BigInt::from(d), i16);
 from_impl!(|d: i8| BigInt::from(d), i8);
 iter_impl!();
-serdes_impl!(|b: &Bn| b.0.to_str_radix(16), |s: &str| {
-    BigInt::from_str_radix(s, 16)
-});
+serdes_impl!(
+    |b: &Bn| b.0.to_str_radix(16),
+    |s: &str| { BigInt::from_str_radix(s, 16).ok() },
+    |b: &Bn| b.0.to_signed_bytes_be(),
+    |s: &[u8]| -> Option<BigInt> { Some(BigInt::from_signed_bytes_be(s)) }
+);
 zeroize_impl!(|b: &mut Bn| b.0.set_zero());
 binops_impl!(Add, add, AddAssign, add_assign, +, +=);
 binops_impl!(Sub, sub, SubAssign, sub_assign, -, -=);

--- a/src/rust_backend.rs
+++ b/src/rust_backend.rs
@@ -247,10 +247,15 @@ impl Bn {
 
     /// Generate a random value less than `n` using the specific random number generator
     pub fn from_rng(n: &Self, rng: &mut impl RngCore) -> Self {
-        let len = (n.0.bits() - 1) / 8;
-        let mut t = vec![0u8; len as usize];
+        let bits = n.0.bits() as usize;
+        let len_bytes = (bits - 1) / 8 + 1;
+        let high_bits = len_bytes * 8 - bits;
+        let mut t = vec![0u8; len_bytes as usize];
         loop {
             rng.fill_bytes(&mut t);
+            if high_bits > 0 {
+                t[0] &= u8::MAX >> high_bits;
+            }
             let b = BigInt::from_bytes_be(Sign::Plus, &t);
             if b < n.0 {
                 return Self(b);

--- a/src/rust_backend.rs
+++ b/src/rust_backend.rs
@@ -224,6 +224,11 @@ impl Bn {
         Self(BigInt::one())
     }
 
+    /// Return the bit length
+    pub fn bit_length(&self) -> usize {
+        self.0.bits() as usize
+    }
+
     /// Compute the greatest common divisor
     pub fn gcd(&self, other: &Self) -> Self {
         Self(self.0.gcd(&other.0))

--- a/tests/bignumber.rs
+++ b/tests/bignumber.rs
@@ -137,7 +137,7 @@ fn clone_negative() {
 }
 
 #[test]
-fn serialize() {
+fn serialize_str() {
     let n = b10(TEST_PRIMES[2]);
     let res = serde_json::to_string(&n);
     assert!(res.is_ok());
@@ -155,6 +155,25 @@ fn serialize() {
     assert_eq!(nn_res.unwrap(), n);
 
     assert!(serde_json::from_str::<BigNumber>(r#""-01""#).is_ok())
+}
+
+#[test]
+fn serialize_bytes() {
+    let n = b10(TEST_PRIMES[2]);
+    let res = bincode::serialize(&n);
+    assert!(res.is_ok());
+    let s = res.unwrap();
+    let nn_res = bincode::deserialize::<BigNumber>(&s);
+    assert!(nn_res.is_ok());
+    assert_eq!(nn_res.unwrap(), n);
+
+    let n = -BigNumber::from(1);
+    let res = bincode::serialize(&n);
+    assert!(res.is_ok());
+    let s = res.unwrap();
+    let nn_res = bincode::deserialize::<BigNumber>(&s);
+    assert!(nn_res.is_ok());
+    assert_eq!(nn_res.unwrap(), n);
 }
 
 #[test]


### PR DESCRIPTION
This is a bit of an eclectic PR, which aims at making `unknown_order` compatible with https://github.com/entropyxyz/tofn. Previously it used a fork of `paillier-rs` and `unknown_order`, but I'm trying to bring the required changes back into the source repo. This is just testing the waters, feel free to propose amendment.

- add `BigNumber::bit_length()`
- fix a compilation error with WASM (`serde_wasm_bindgen::from_value()` is the recommended way now instead of `value.into_serde()`)
- fix a bug in Rust backend where `from_rng()` generated randoms of a wrong size when size wasn't a multiple of 8
- add `BigNumber::prime_from_rng()`
- add `BigNumber::safe_prime_from_rng()`
- fix the behavior of `_random_nbit()` in Rust backend (it was generating a random with the highest bit always set)
- support text-based/binary formats for BigNumber serialization (as hex for string-based, and as binary for binary). Two questions here: 1) is it important for the serialization to be compatible cross-backends? Because it's currently not. 2) Does it make sense for `BigNumber` to be signed? If it can be unsigned, that would allow us to fix 1). Currently for GMP and OpenSSL backends I'm adding a sign byte in front of the binary representation because their serialization methods ignore the sign.
- Fix incorrect operators used in `binops_group` macro (seems like a copy-paste artefact, `+` was used instead of the correct operator)
- Made the crate `no_std`.